### PR TITLE
Add compare season anime page

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -290,6 +290,115 @@ interface MediaListResponse {
 	errors?: { message: string }[];
 }
 
+// ============================================================================
+// Compare Season Types & Server Function
+// ============================================================================
+
+export type AnimeSeason = "WINTER" | "SPRING" | "SUMMER" | "FALL";
+
+export interface SeasonMediaEntry {
+	score: number;
+	status: string;
+	progress: number;
+	media: {
+		id: number;
+		title: {
+			userPreferred: string;
+			english: string | null;
+			romaji: string | null;
+		};
+		coverImage: {
+			large: string;
+		};
+		season: AnimeSeason | null;
+		seasonYear: number | null;
+		genres: string[];
+		tags: { name: string; rank: number }[];
+		averageScore: number | null;
+		meanScore: number | null;
+		format: string;
+		episodes: number | null;
+		status: string;
+	};
+}
+
+interface SeasonMediaListCollection {
+	data: {
+		MediaListCollection: {
+			lists: {
+				name: string;
+				status: string;
+				entries: SeasonMediaEntry[];
+			}[];
+		} | null;
+	};
+	errors?: { message: string }[];
+}
+
+export const getSeasonAnimeList = createServerFn({ method: "GET" })
+	.validator(z.object({ userName: z.string() }))
+	.handler(async (ctx): Promise<SeasonMediaListCollection> => {
+		const { userName } = ctx.data;
+
+		const response = await fetch("https://graphql.anilist.co", {
+			method: "POST",
+			body: JSON.stringify({
+				query: `
+					query($userName: String, $type: MediaType) {
+						MediaListCollection(userName: $userName, type: $type) {
+							lists {
+								name
+								status
+								entries {
+									score
+									status
+									progress
+									media {
+										id
+										title {
+											userPreferred
+											english
+											romaji
+										}
+										coverImage {
+											large
+										}
+										season
+										seasonYear
+										genres
+										tags {
+											name
+											rank
+										}
+										averageScore
+										meanScore
+										format
+										episodes
+										status
+									}
+								}
+							}
+						}
+					}
+				`,
+				variables: {
+					userName,
+					type: "ANIME",
+				},
+			}),
+			headers: {
+				"Content-Type": "application/json",
+			},
+		});
+
+		const data: SeasonMediaListCollection = await response.json();
+		return data;
+	});
+
+// ============================================================================
+// Currently Watching
+// ============================================================================
+
 export const getCurrentlyWatching = createServerFn({ method: "GET" })
 	.validator(
 		z.object({

--- a/src/components/CompareStats.tsx
+++ b/src/components/CompareStats.tsx
@@ -1,0 +1,396 @@
+import {
+	Bar,
+	BarChart,
+	CartesianGrid,
+	PolarAngleAxis,
+	PolarGrid,
+	Radar,
+	RadarChart,
+	XAxis,
+	YAxis,
+} from "recharts";
+import type { CompareStats as CompareStatsType } from "~/lib/compare-utils";
+import { Badge } from "~/components/ui/badge";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "~/components/ui/tabs";
+import {
+	ChartContainer,
+	ChartTooltip,
+	ChartTooltipContent,
+	ChartLegend,
+	ChartLegendContent,
+	type ChartConfig,
+} from "~/components/ui/chart";
+
+const USER_COLORS = ["#f472b6", "#a78bfa", "#60a5fa"];
+const USER_GRADIENT_CLASSES = [
+	"from-pink-400 to-rose-400",
+	"from-purple-400 to-indigo-400",
+	"from-blue-400 to-cyan-400",
+];
+
+interface CompareStatsProps {
+	stats: CompareStatsType;
+	userNames: string[];
+}
+
+// ============================================================================
+// Overview Tab
+// ============================================================================
+
+function OverviewCards({ stats, userNames }: CompareStatsProps) {
+	const mostAnime = userNames.reduce((a, b) =>
+		(stats.animeCount[a] || 0) >= (stats.animeCount[b] || 0) ? a : b,
+	);
+	const highestAvg = userNames.reduce((a, b) =>
+		(stats.averageScores[a] || 0) >= (stats.averageScores[b] || 0) ? a : b,
+	);
+
+	return (
+		<div className="space-y-6">
+			{/* Summary cards */}
+			<div className="grid grid-cols-2 sm:grid-cols-3 gap-4">
+				<div className="bg-gradient-to-br from-pink-100 to-rose-100 rounded-2xl p-4 border-2 border-pink-200 text-center">
+					<div className="text-3xl mb-1">{stats.sharedCount}</div>
+					<div className="text-sm text-gray-600 font-medium">Shared Anime</div>
+				</div>
+				{userNames.map((name, i) => (
+					<div
+						key={name}
+						className="bg-gradient-to-br from-purple-50 to-indigo-50 rounded-2xl p-4 border-2 border-purple-200 text-center"
+					>
+						<div className="text-3xl mb-1">{stats.animeCount[name] || 0}</div>
+						<div className="text-sm text-gray-600 font-medium truncate">
+							<span className={`bg-gradient-to-r ${USER_GRADIENT_CLASSES[i]} bg-clip-text text-transparent font-bold`}>
+								{name}
+							</span>
+						</div>
+						<div className="text-xs text-gray-400 mt-1">
+							{stats.uniqueCounts[name] || 0} unique
+						</div>
+					</div>
+				))}
+			</div>
+
+			{/* Average scores */}
+			<div className="bg-white/60 backdrop-blur-sm rounded-2xl p-6 border-2 border-purple-100">
+				<h3 className="text-lg font-bold text-gray-800 mb-4">Average Scores</h3>
+				<div className="space-y-3">
+					{userNames.map((name, i) => {
+						const avg = stats.averageScores[name] || 0;
+						return (
+							<div key={name} className="flex items-center gap-3">
+								<span className={`bg-gradient-to-r ${USER_GRADIENT_CLASSES[i]} bg-clip-text text-transparent font-bold min-w-[100px] truncate`}>
+									{name}
+								</span>
+								<div className="flex-1 bg-gray-100 rounded-full h-4 overflow-hidden">
+									<div
+										className="h-full rounded-full transition-all duration-500"
+										style={{
+											width: `${(avg / 10) * 100}%`,
+											backgroundColor: USER_COLORS[i],
+										}}
+									/>
+								</div>
+								<span className="font-bold text-gray-700 min-w-[40px] text-right">
+									{avg > 0 ? avg.toFixed(1) : "N/A"}
+								</span>
+							</div>
+						);
+					})}
+				</div>
+			</div>
+
+			{/* Fun highlights */}
+			<div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+				<div className="bg-gradient-to-br from-yellow-50 to-orange-50 rounded-2xl p-4 border-2 border-yellow-200">
+					<div className="text-2xl mb-2">📺</div>
+					<div className="text-sm font-medium text-gray-700">Watches the Most</div>
+					<div className="text-lg font-bold text-gray-800">{mostAnime}</div>
+					<div className="text-xs text-gray-500">{stats.animeCount[mostAnime]} anime this season</div>
+				</div>
+				<div className="bg-gradient-to-br from-green-50 to-emerald-50 rounded-2xl p-4 border-2 border-green-200">
+					<div className="text-2xl mb-2">⭐</div>
+					<div className="text-sm font-medium text-gray-700">Highest Average Score</div>
+					<div className="text-lg font-bold text-gray-800">{highestAvg}</div>
+					<div className="text-xs text-gray-500">
+						{stats.averageScores[highestAvg] > 0
+							? `${stats.averageScores[highestAvg].toFixed(1)} / 10`
+							: "No scores yet"}
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+// ============================================================================
+// Score Distribution Tab
+// ============================================================================
+
+function ScoreDistributionChart({ stats, userNames }: CompareStatsProps) {
+	const chartData = Array.from({ length: 10 }, (_, i) => {
+		const score = i + 1;
+		const row: Record<string, number | string> = { score: score.toString() };
+		for (const name of userNames) {
+			row[name] = stats.scoreDistribution[name]?.[score] || 0;
+		}
+		return row;
+	});
+
+	const chartConfig: ChartConfig = {};
+	for (let i = 0; i < userNames.length; i++) {
+		chartConfig[userNames[i]] = {
+			label: userNames[i],
+			color: USER_COLORS[i],
+		};
+	}
+
+	return (
+		<div className="bg-white/60 backdrop-blur-sm rounded-2xl p-6 border-2 border-purple-100">
+			<h3 className="text-lg font-bold text-gray-800 mb-4">Score Distribution</h3>
+			<ChartContainer config={chartConfig} className="h-[300px] w-full">
+				<BarChart data={chartData}>
+					<CartesianGrid strokeDasharray="3 3" />
+					<XAxis dataKey="score" label={{ value: "Score", position: "insideBottom", offset: -5 }} />
+					<YAxis allowDecimals={false} />
+					<ChartTooltip content={<ChartTooltipContent />} />
+					<ChartLegend content={<ChartLegendContent />} />
+					{userNames.map((name, i) => (
+						<Bar
+							key={name}
+							dataKey={name}
+							fill={USER_COLORS[i]}
+							radius={[4, 4, 0, 0]}
+						/>
+					))}
+				</BarChart>
+			</ChartContainer>
+		</div>
+	);
+}
+
+// ============================================================================
+// Genre Radar Tab
+// ============================================================================
+
+function GenreRadarChart({ stats, userNames }: CompareStatsProps) {
+	// Collect all genres and find top 8
+	const genreTotals: Record<string, number> = {};
+	for (const name of userNames) {
+		for (const [genre, count] of Object.entries(stats.genreDistribution[name] || {})) {
+			genreTotals[genre] = (genreTotals[genre] || 0) + count;
+		}
+	}
+	const topGenres = Object.entries(genreTotals)
+		.sort((a, b) => b[1] - a[1])
+		.slice(0, 8)
+		.map(([genre]) => genre);
+
+	if (topGenres.length === 0) {
+		return (
+			<div className="text-center py-8 text-gray-500">
+				No genre data available for this season.
+			</div>
+		);
+	}
+
+	const chartData = topGenres.map((genre) => {
+		const row: Record<string, number | string> = { genre };
+		for (const name of userNames) {
+			row[name] = stats.genreDistribution[name]?.[genre] || 0;
+		}
+		return row;
+	});
+
+	const chartConfig: ChartConfig = {};
+	for (let i = 0; i < userNames.length; i++) {
+		chartConfig[userNames[i]] = {
+			label: userNames[i],
+			color: USER_COLORS[i],
+		};
+	}
+
+	return (
+		<div className="bg-white/60 backdrop-blur-sm rounded-2xl p-6 border-2 border-purple-100">
+			<h3 className="text-lg font-bold text-gray-800 mb-4">Genre Preferences</h3>
+			<ChartContainer config={chartConfig} className="h-[350px] w-full">
+				<RadarChart data={chartData}>
+					<PolarGrid />
+					<PolarAngleAxis dataKey="genre" className="text-xs" />
+					<ChartTooltip content={<ChartTooltipContent />} />
+					<ChartLegend content={<ChartLegendContent />} />
+					{userNames.map((name, i) => (
+						<Radar
+							key={name}
+							name={name}
+							dataKey={name}
+							stroke={USER_COLORS[i]}
+							fill={USER_COLORS[i]}
+							fillOpacity={0.15}
+						/>
+					))}
+				</RadarChart>
+			</ChartContainer>
+		</div>
+	);
+}
+
+// ============================================================================
+// Tags & Disagreements Tab
+// ============================================================================
+
+function TagsAndDisagreements({ stats, userNames }: CompareStatsProps) {
+	return (
+		<div className="space-y-6">
+			{/* Top tags per user */}
+			<div className="bg-white/60 backdrop-blur-sm rounded-2xl p-6 border-2 border-purple-100">
+				<h3 className="text-lg font-bold text-gray-800 mb-4">Top Tags</h3>
+				<div className="space-y-4">
+					{userNames.map((name, i) => {
+						const tags = Object.entries(stats.tagDistribution[name] || {})
+							.sort((a, b) => b[1] - a[1])
+							.slice(0, 10);
+						return (
+							<div key={name}>
+								<div className={`bg-gradient-to-r ${USER_GRADIENT_CLASSES[i]} bg-clip-text text-transparent font-bold mb-2`}>
+									{name}
+								</div>
+								<div className="flex flex-wrap gap-1.5">
+									{tags.length > 0 ? (
+										tags.map(([tag, count]) => (
+											<Badge
+												key={tag}
+												variant="outline"
+												className="text-xs"
+												style={{ borderColor: USER_COLORS[i], color: USER_COLORS[i] }}
+											>
+												{tag} ({count})
+											</Badge>
+										))
+									) : (
+										<span className="text-sm text-gray-400">No tag data</span>
+									)}
+								</div>
+							</div>
+						);
+					})}
+				</div>
+			</div>
+
+			{/* Biggest disagreements */}
+			{stats.biggestDisagreements.length > 0 && (
+				<div className="bg-gradient-to-br from-red-50 to-orange-50 rounded-2xl p-6 border-2 border-red-200">
+					<h3 className="text-lg font-bold text-gray-800 mb-4">
+						🔥 Biggest Disagreements
+					</h3>
+					<div className="space-y-3">
+						{stats.biggestDisagreements.map((item) => (
+							<div
+								key={item.media.id}
+								className="flex items-center gap-3 bg-white/60 rounded-xl p-3"
+							>
+								<img
+									src={item.media.coverImage.large}
+									alt={item.media.title.userPreferred}
+									className="w-8 h-12 rounded-lg object-cover"
+								/>
+								<div className="flex-1 min-w-0">
+									<p className="font-medium text-sm text-gray-800 truncate">
+										{item.media.title.userPreferred}
+									</p>
+									<div className="flex gap-2 mt-1">
+										{userNames.map((name, i) => (
+											<span key={name} className="text-xs" style={{ color: USER_COLORS[i] }}>
+												{item.scores[name] != null ? `${name}: ${item.scores[name]}` : ""}
+											</span>
+										))}
+									</div>
+								</div>
+								<Badge variant="destructive" className="text-xs shrink-0">
+									{item.maxDelta} gap
+								</Badge>
+							</div>
+						))}
+					</div>
+				</div>
+			)}
+
+			{/* Biggest agreements */}
+			{stats.biggestAgreements.length > 0 && (
+				<div className="bg-gradient-to-br from-green-50 to-emerald-50 rounded-2xl p-6 border-2 border-green-200">
+					<h3 className="text-lg font-bold text-gray-800 mb-4">
+						💚 Most Agreed On
+					</h3>
+					<div className="space-y-3">
+						{stats.biggestAgreements.map((item) => (
+							<div
+								key={item.media.id}
+								className="flex items-center gap-3 bg-white/60 rounded-xl p-3"
+							>
+								<img
+									src={item.media.coverImage.large}
+									alt={item.media.title.userPreferred}
+									className="w-8 h-12 rounded-lg object-cover"
+								/>
+								<div className="flex-1 min-w-0">
+									<p className="font-medium text-sm text-gray-800 truncate">
+										{item.media.title.userPreferred}
+									</p>
+									<div className="flex gap-2 mt-1">
+										{userNames.map((name, i) => (
+											<span key={name} className="text-xs" style={{ color: USER_COLORS[i] }}>
+												{item.scores[name] != null ? `${name}: ${item.scores[name]}` : ""}
+											</span>
+										))}
+									</div>
+								</div>
+								<Badge variant="outline" className="text-xs shrink-0 border-green-300 text-green-700">
+									{item.maxDelta === 0 ? "Same!" : `${item.maxDelta} gap`}
+								</Badge>
+							</div>
+						))}
+					</div>
+				</div>
+			)}
+		</div>
+	);
+}
+
+// ============================================================================
+// Main CompareStats Component
+// ============================================================================
+
+export function CompareStats({ stats, userNames }: CompareStatsProps) {
+	return (
+		<div className="space-y-6">
+			<h2 className="text-2xl font-bold bg-gradient-to-r from-purple-400 to-blue-400 bg-clip-text text-transparent text-center">
+				📊 Statistics 📊
+			</h2>
+
+			<Tabs defaultValue="overview" className="w-full">
+				<TabsList className="w-full flex flex-wrap h-auto">
+					<TabsTrigger value="overview">Overview</TabsTrigger>
+					<TabsTrigger value="scores">Scores</TabsTrigger>
+					<TabsTrigger value="genres">Genres</TabsTrigger>
+					<TabsTrigger value="tags">Tags & Opinions</TabsTrigger>
+				</TabsList>
+
+				<TabsContent value="overview" className="mt-4">
+					<OverviewCards stats={stats} userNames={userNames} />
+				</TabsContent>
+
+				<TabsContent value="scores" className="mt-4">
+					<ScoreDistributionChart stats={stats} userNames={userNames} />
+				</TabsContent>
+
+				<TabsContent value="genres" className="mt-4">
+					<GenreRadarChart stats={stats} userNames={userNames} />
+				</TabsContent>
+
+				<TabsContent value="tags" className="mt-4">
+					<TagsAndDisagreements stats={stats} userNames={userNames} />
+				</TabsContent>
+			</Tabs>
+		</div>
+	);
+}

--- a/src/components/CompareTable.tsx
+++ b/src/components/CompareTable.tsx
@@ -1,0 +1,187 @@
+import type { AnilistUser } from "server";
+import type { MergedAnimeEntry } from "~/lib/compare-utils";
+import { Badge } from "~/components/ui/badge";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "~/components/ui/table";
+import { useState } from "react";
+
+interface CompareTableProps {
+	mergedEntries: Map<number, MergedAnimeEntry>;
+	users: { name: string; user: AnilistUser | null }[];
+}
+
+type SortKey = "title" | "avgScore" | string; // string for user-specific sorts
+type SortDir = "asc" | "desc";
+
+function getScoreColor(score: number): string {
+	if (score >= 8) return "bg-green-100 text-green-800";
+	if (score >= 5) return "bg-yellow-100 text-yellow-800";
+	if (score >= 1) return "bg-red-100 text-red-800";
+	return "bg-gray-50 text-gray-400";
+}
+
+function getStatusBadge(status: string) {
+	const config: Record<string, { label: string; className: string }> = {
+		CURRENT: { label: "Watching", className: "bg-blue-100 text-blue-700 border-blue-200" },
+		COMPLETED: { label: "Completed", className: "bg-green-100 text-green-700 border-green-200" },
+		PLANNING: { label: "Planning", className: "bg-purple-100 text-purple-700 border-purple-200" },
+		DROPPED: { label: "Dropped", className: "bg-red-100 text-red-700 border-red-200" },
+		PAUSED: { label: "Paused", className: "bg-yellow-100 text-yellow-700 border-yellow-200" },
+		REPEATING: { label: "Rewatching", className: "bg-cyan-100 text-cyan-700 border-cyan-200" },
+	};
+	const c = config[status] || { label: status, className: "bg-gray-100 text-gray-700 border-gray-200" };
+	return (
+		<Badge variant="outline" className={`text-[10px] ${c.className}`}>
+			{c.label}
+		</Badge>
+	);
+}
+
+const USER_COLORS = ["from-pink-400 to-rose-400", "from-purple-400 to-indigo-400", "from-blue-400 to-cyan-400"];
+
+export function CompareTable({ mergedEntries, users }: CompareTableProps) {
+	const [sortKey, setSortKey] = useState<SortKey>("title");
+	const [sortDir, setSortDir] = useState<SortDir>("asc");
+
+	const entries = Array.from(mergedEntries.values());
+
+	const sorted = [...entries].sort((a, b) => {
+		let comparison = 0;
+
+		if (sortKey === "title") {
+			comparison = a.media.title.userPreferred.localeCompare(b.media.title.userPreferred);
+		} else if (sortKey === "avgScore") {
+			comparison = (a.media.averageScore || 0) - (b.media.averageScore || 0);
+		} else {
+			// Sort by a specific user's score
+			const aScore = a.users[sortKey]?.score || 0;
+			const bScore = b.users[sortKey]?.score || 0;
+			comparison = aScore - bScore;
+		}
+
+		return sortDir === "asc" ? comparison : -comparison;
+	});
+
+	const handleSort = (key: SortKey) => {
+		if (sortKey === key) {
+			setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+		} else {
+			setSortKey(key);
+			setSortDir(key === "title" ? "asc" : "desc");
+		}
+	};
+
+	const sortIcon = (key: SortKey) => {
+		if (sortKey !== key) return " ↕";
+		return sortDir === "asc" ? " ↑" : " ↓";
+	};
+
+	if (entries.length === 0) {
+		return (
+			<div className="text-center py-12">
+				<div className="text-4xl mb-4">🤔</div>
+				<p className="text-lg text-gray-600">
+					No anime found for this season. Try a different season or year!
+				</p>
+			</div>
+		);
+	}
+
+	return (
+		<div className="bg-white/80 backdrop-blur-sm rounded-2xl border-2 border-purple-100 shadow-lg overflow-hidden">
+			<Table>
+				<TableHeader>
+					<TableRow className="bg-gradient-to-r from-pink-50 to-purple-50">
+						<TableHead
+							className="cursor-pointer hover:bg-purple-100/50 transition-colors min-w-[250px]"
+							onClick={() => handleSort("title")}
+						>
+							Anime{sortIcon("title")}
+						</TableHead>
+						{users.map((u, i) => (
+							<TableHead
+								key={u.name}
+								className="cursor-pointer hover:bg-purple-100/50 transition-colors text-center min-w-[120px]"
+								onClick={() => handleSort(u.name)}
+							>
+								<div className="flex flex-col items-center gap-1">
+									{u.user?.avatar?.medium && (
+										<img
+											src={u.user.avatar.medium}
+											alt={u.name}
+											className="w-6 h-6 rounded-full"
+										/>
+									)}
+									<span className={`bg-gradient-to-r ${USER_COLORS[i]} bg-clip-text text-transparent font-bold`}>
+										{u.name}
+									</span>
+									<span className="text-[10px] text-gray-400">{sortIcon(u.name)}</span>
+								</div>
+							</TableHead>
+						))}
+						<TableHead
+							className="cursor-pointer hover:bg-purple-100/50 transition-colors text-center min-w-[80px]"
+							onClick={() => handleSort("avgScore")}
+						>
+							AL Avg{sortIcon("avgScore")}
+						</TableHead>
+					</TableRow>
+				</TableHeader>
+				<TableBody>
+					{sorted.map((entry) => (
+						<TableRow key={entry.media.id} className="hover:bg-purple-50/30 transition-colors">
+							<TableCell>
+								<div className="flex items-center gap-3">
+									<img
+										src={entry.media.coverImage.large}
+										alt={entry.media.title.userPreferred}
+										className="w-10 h-14 rounded-lg object-cover shadow-sm"
+									/>
+									<div className="min-w-0">
+										<p className="font-medium text-sm text-gray-800 truncate max-w-[200px]">
+											{entry.media.title.userPreferred}
+										</p>
+										<p className="text-[10px] text-gray-400">
+											{entry.media.format} {entry.media.episodes ? `· ${entry.media.episodes} eps` : ""}
+										</p>
+									</div>
+								</div>
+							</TableCell>
+							{users.map((u) => {
+								const userData = entry.users[u.name];
+								if (!userData) {
+									return (
+										<TableCell key={u.name} className="text-center">
+											<span className="text-gray-300">---</span>
+										</TableCell>
+									);
+								}
+								return (
+									<TableCell key={u.name} className="text-center">
+										<div className="flex flex-col items-center gap-1">
+											<span className={`inline-flex items-center justify-center w-8 h-8 rounded-full text-sm font-bold ${getScoreColor(userData.score)}`}>
+												{userData.score > 0 ? userData.score : "-"}
+											</span>
+											{getStatusBadge(userData.status)}
+										</div>
+									</TableCell>
+								);
+							})}
+							<TableCell className="text-center">
+								<span className="text-sm text-gray-600 font-medium">
+									{entry.media.averageScore ? `${entry.media.averageScore}%` : "-"}
+								</span>
+							</TableCell>
+						</TableRow>
+					))}
+				</TableBody>
+			</Table>
+		</div>
+	);
+}

--- a/src/lib/compare-utils.ts
+++ b/src/lib/compare-utils.ts
@@ -1,0 +1,242 @@
+import type { AnimeSeason, AnilistUser, SeasonMediaEntry } from "server";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface UserAnimeData {
+	score: number;
+	status: string;
+	progress: number;
+}
+
+export interface MergedAnimeEntry {
+	media: SeasonMediaEntry["media"];
+	users: Record<string, UserAnimeData | null>;
+}
+
+export interface CompareStats {
+	averageScores: Record<string, number>;
+	animeCount: Record<string, number>;
+	sharedCount: number;
+	uniqueCounts: Record<string, number>;
+	scoreDistribution: Record<string, number[]>;
+	genreDistribution: Record<string, Record<string, number>>;
+	tagDistribution: Record<string, Record<string, number>>;
+	biggestDisagreements: {
+		media: SeasonMediaEntry["media"];
+		scores: Record<string, number>;
+		maxDelta: number;
+	}[];
+	biggestAgreements: {
+		media: SeasonMediaEntry["media"];
+		scores: Record<string, number>;
+		maxDelta: number;
+	}[];
+}
+
+export interface UserSeasonData {
+	user: AnilistUser;
+	entries: SeasonMediaEntry[];
+}
+
+// ============================================================================
+// Season Helpers
+// ============================================================================
+
+export function getCurrentSeason(): { season: AnimeSeason; year: number } {
+	const now = new Date();
+	const month = now.getMonth() + 1;
+	const year = now.getFullYear();
+
+	let season: AnimeSeason;
+	if (month >= 1 && month <= 3) season = "WINTER";
+	else if (month >= 4 && month <= 6) season = "SPRING";
+	else if (month >= 7 && month <= 9) season = "SUMMER";
+	else season = "FALL";
+
+	return { season, year };
+}
+
+export const SEASONS: AnimeSeason[] = ["WINTER", "SPRING", "SUMMER", "FALL"];
+
+export function getYearRange(): number[] {
+	const currentYear = new Date().getFullYear();
+	const years: number[] = [];
+	for (let y = currentYear + 1; y >= 2006; y--) {
+		years.push(y);
+	}
+	return years;
+}
+
+// ============================================================================
+// Data Processing
+// ============================================================================
+
+export function filterBySeason(
+	entries: SeasonMediaEntry[],
+	season: AnimeSeason,
+	year: number,
+): SeasonMediaEntry[] {
+	return entries.filter(
+		(e) => e.media.season === season && e.media.seasonYear === year,
+	);
+}
+
+export function mergeUserData(
+	usersData: { userName: string; entries: SeasonMediaEntry[] }[],
+): Map<number, MergedAnimeEntry> {
+	const merged = new Map<number, MergedAnimeEntry>();
+
+	for (const { userName, entries } of usersData) {
+		for (const entry of entries) {
+			const mediaId = entry.media.id;
+			if (!merged.has(mediaId)) {
+				merged.set(mediaId, {
+					media: entry.media,
+					users: {},
+				});
+			}
+			const existing = merged.get(mediaId)!;
+			existing.users[userName] = {
+				score: entry.score,
+				status: entry.status,
+				progress: entry.progress,
+			};
+		}
+	}
+
+	return merged;
+}
+
+// ============================================================================
+// Statistics
+// ============================================================================
+
+export function computeStats(
+	mergedEntries: Map<number, MergedAnimeEntry>,
+	userNames: string[],
+): CompareStats {
+	const averageScores: Record<string, number> = {};
+	const animeCount: Record<string, number> = {};
+	const uniqueCounts: Record<string, number> = {};
+	const scoreDistribution: Record<string, number[]> = {};
+	const genreDistribution: Record<string, Record<string, number>> = {};
+	const tagDistribution: Record<string, Record<string, number>> = {};
+
+	// Initialize per-user accumulators
+	for (const name of userNames) {
+		animeCount[name] = 0;
+		uniqueCounts[name] = 0;
+		// 11 buckets: index 0 unused, 1-10 for scores
+		scoreDistribution[name] = new Array(11).fill(0);
+		genreDistribution[name] = {};
+		tagDistribution[name] = {};
+	}
+
+	let sharedCount = 0;
+	const scoreSums: Record<string, number> = {};
+	const scoreCounts: Record<string, number> = {};
+	for (const name of userNames) {
+		scoreSums[name] = 0;
+		scoreCounts[name] = 0;
+	}
+
+	// For disagreements
+	const sharedAnimeScores: {
+		media: SeasonMediaEntry["media"];
+		scores: Record<string, number>;
+	}[] = [];
+
+	for (const entry of mergedEntries.values()) {
+		const presentUsers = userNames.filter((n) => entry.users[n] != null);
+
+		// Count shared (all users have it)
+		if (presentUsers.length === userNames.length) {
+			sharedCount++;
+		}
+
+		// Count unique (only one user has it)
+		if (presentUsers.length === 1) {
+			uniqueCounts[presentUsers[0]]++;
+		}
+
+		for (const userName of presentUsers) {
+			const userData = entry.users[userName]!;
+			animeCount[userName]++;
+
+			// Score stats
+			if (userData.score > 0) {
+				scoreSums[userName] += userData.score;
+				scoreCounts[userName]++;
+				const bucket = Math.min(Math.round(userData.score), 10);
+				if (bucket >= 1) {
+					scoreDistribution[userName][bucket]++;
+				}
+			}
+
+			// Genre distribution
+			for (const genre of entry.media.genres) {
+				genreDistribution[userName][genre] =
+					(genreDistribution[userName][genre] || 0) + 1;
+			}
+
+			// Tag distribution (only meaningful tags with rank >= 60)
+			for (const tag of entry.media.tags) {
+				if (tag.rank >= 60) {
+					tagDistribution[userName][tag.name] =
+						(tagDistribution[userName][tag.name] || 0) + 1;
+				}
+			}
+		}
+
+		// Collect scores for shared anime (for disagreements)
+		if (presentUsers.length >= 2) {
+			const scores: Record<string, number> = {};
+			let allScored = true;
+			for (const userName of presentUsers) {
+				const s = entry.users[userName]!.score;
+				if (s > 0) {
+					scores[userName] = s;
+				} else {
+					allScored = false;
+				}
+			}
+			if (allScored && Object.keys(scores).length >= 2) {
+				sharedAnimeScores.push({ media: entry.media, scores });
+			}
+		}
+	}
+
+	// Compute averages
+	for (const name of userNames) {
+		averageScores[name] =
+			scoreCounts[name] > 0 ? scoreSums[name] / scoreCounts[name] : 0;
+	}
+
+	// Compute disagreements
+	const withDeltas = sharedAnimeScores.map((item) => {
+		const scoreValues = Object.values(item.scores);
+		const maxDelta = Math.max(...scoreValues) - Math.min(...scoreValues);
+		return { ...item, maxDelta };
+	});
+
+	withDeltas.sort((a, b) => b.maxDelta - a.maxDelta);
+
+	const biggestDisagreements = withDeltas.slice(0, 5);
+	const biggestAgreements = [...withDeltas]
+		.sort((a, b) => a.maxDelta - b.maxDelta)
+		.slice(0, 5);
+
+	return {
+		averageScores,
+		animeCount,
+		sharedCount,
+		uniqueCounts,
+		scoreDistribution,
+		genreDistribution,
+		tagDistribution,
+		biggestDisagreements,
+		biggestAgreements,
+	};
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -9,8 +9,14 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as CompareRouteImport } from './routes/compare'
 import { Route as IndexRouteImport } from './routes/index'
 
+const CompareRoute = CompareRouteImport.update({
+  id: '/compare',
+  path: '/compare',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
@@ -19,28 +25,39 @@ const IndexRoute = IndexRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/compare': typeof CompareRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/compare': typeof CompareRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/compare': typeof CompareRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/'
+  fullPaths: '/' | '/compare'
   fileRoutesByTo: FileRoutesByTo
-  to: '/'
-  id: '__root__' | '/'
+  to: '/' | '/compare'
+  id: '__root__' | '/' | '/compare'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  CompareRoute: typeof CompareRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/compare': {
+      id: '/compare'
+      path: '/compare'
+      fullPath: '/compare'
+      preLoaderRoute: typeof CompareRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/': {
       id: '/'
       path: '/'
@@ -53,6 +70,7 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  CompareRoute: CompareRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,5 +1,6 @@
 import type { QueryClient } from "@tanstack/react-query";
 import {
+  Link,
   createRootRouteWithContext,
   HeadContent,
   Outlet,
@@ -100,6 +101,38 @@ function RootComponent() {
   );
 }
 
+function NavBar() {
+  return (
+    <nav className="bg-white/60 backdrop-blur-sm border-b-2 border-purple-100 px-6 py-3">
+      <div className="max-w-6xl mx-auto flex items-center justify-between">
+        <Link
+          to="/"
+          className="text-lg font-bold bg-gradient-to-r from-pink-400 to-purple-400 bg-clip-text text-transparent"
+        >
+          🌸 AniList Tracker
+        </Link>
+        <div className="flex gap-4">
+          <Link
+            to="/"
+            className="text-sm text-gray-600 hover:text-purple-600 font-medium transition-colors"
+            activeProps={{ className: "text-sm text-purple-600 font-bold transition-colors" }}
+            activeOptions={{ exact: true }}
+          >
+            📺 Watching
+          </Link>
+          <Link
+            to="/compare"
+            className="text-sm text-gray-600 hover:text-purple-600 font-medium transition-colors"
+            activeProps={{ className: "text-sm text-purple-600 font-bold transition-colors" }}
+          >
+            ⚔️ Compare
+          </Link>
+        </div>
+      </div>
+    </nav>
+  );
+}
+
 function RootDocument({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
@@ -107,6 +140,7 @@ function RootDocument({ children }: { children: React.ReactNode }) {
         <HeadContent />
       </head>
       <body>
+        <NavBar />
         {children}
         <Toaster />
         <Scripts />

--- a/src/routes/compare.tsx
+++ b/src/routes/compare.tsx
@@ -1,0 +1,408 @@
+import { queryOptions, useQuery } from "@tanstack/react-query";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { useState } from "react";
+import { z } from "zod";
+import {
+	getCurrentUser,
+	getSeasonAnimeList,
+	type AnimeSeason,
+	type AnilistUser,
+	type SeasonMediaEntry,
+} from "server";
+import { Button } from "~/components/ui/button";
+import { Card, CardContent } from "~/components/ui/card";
+import { Input } from "~/components/ui/input";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "~/components/ui/select";
+import { AnimeLoading } from "~/components/KawaiiLoading";
+import { CompareTable } from "~/components/CompareTable";
+import { CompareStats } from "~/components/CompareStats";
+import {
+	getCurrentSeason,
+	getYearRange,
+	SEASONS,
+	filterBySeason,
+	mergeUserData,
+	computeStats,
+} from "~/lib/compare-utils";
+
+// ============================================================================
+// Route Definition
+// ============================================================================
+
+const compareSearchSchema = z.object({
+	userA: z.string().optional(),
+	userB: z.string().optional(),
+	userC: z.string().optional(),
+	season: z.enum(["WINTER", "SPRING", "SUMMER", "FALL"]).optional(),
+	year: z.coerce.number().optional(),
+});
+
+export const Route = createFileRoute("/compare")({
+	component: ComparePage,
+	validateSearch: compareSearchSchema,
+});
+
+// ============================================================================
+// Query Options
+// ============================================================================
+
+const useUserQuery = (userName: string | undefined) =>
+	queryOptions({
+		queryKey: ["user", userName],
+		queryFn: async () => {
+			if (!userName) throw new Error("No username");
+			const response = await getCurrentUser({ data: { userName } });
+			if (response.errors?.length) {
+				throw new Error(response.errors[0].message);
+			}
+			return response.data.User;
+		},
+		enabled: !!userName,
+		retry: false,
+		staleTime: 5 * 60 * 1000,
+	});
+
+const useSeasonListQuery = (userName: string | undefined) =>
+	queryOptions({
+		queryKey: ["seasonAnimeList", userName],
+		queryFn: async () => {
+			if (!userName) throw new Error("No username");
+			const response = await getSeasonAnimeList({ data: { userName } });
+			if (response.errors?.length) {
+				throw new Error(response.errors[0].message);
+			}
+			const lists = response.data.MediaListCollection?.lists || [];
+			return lists.flatMap((list) => list.entries);
+		},
+		enabled: !!userName,
+		retry: false,
+		staleTime: 5 * 60 * 1000,
+	});
+
+// ============================================================================
+// Components
+// ============================================================================
+
+function CompareHeader() {
+	return (
+		<div className="text-center mb-8">
+			<h1 className="text-4xl font-bold bg-gradient-to-r from-pink-400 via-purple-400 to-blue-400 bg-clip-text text-transparent mb-2">
+				⚔️ Compare Season Anime ⚔️
+			</h1>
+			<p className="text-lg text-gray-600 font-medium">
+				(^_^) Compare your anime taste with friends!
+			</p>
+		</div>
+	);
+}
+
+interface UserInputError {
+	userA?: string;
+	userB?: string;
+	userC?: string;
+}
+
+function ComparePage() {
+	const search = Route.useSearch();
+	const navigate = useNavigate();
+	const currentSeason = getCurrentSeason();
+	const years = getYearRange();
+
+	// Local form state (before submitting)
+	const [inputA, setInputA] = useState(search.userA || "");
+	const [inputB, setInputB] = useState(search.userB || "");
+	const [inputC, setInputC] = useState(search.userC || "");
+	const [showThirdUser, setShowThirdUser] = useState(!!search.userC);
+	const [selectedSeason, setSelectedSeason] = useState<AnimeSeason>(
+		search.season || currentSeason.season,
+	);
+	const [selectedYear, setSelectedYear] = useState(
+		search.year || currentSeason.year,
+	);
+
+	// "submitted" usernames (from URL search params)
+	const submittedA = search.userA;
+	const submittedB = search.userB;
+	const submittedC = search.userC;
+	const submittedSeason = search.season;
+	const submittedYear = search.year;
+
+	// User profile queries
+	const userAQuery = useQuery(useUserQuery(submittedA));
+	const userBQuery = useQuery(useUserQuery(submittedB));
+	const userCQuery = useQuery(useUserQuery(submittedC));
+
+	// Anime list queries
+	const listAQuery = useQuery(useSeasonListQuery(submittedA));
+	const listBQuery = useQuery(useSeasonListQuery(submittedB));
+	const listCQuery = useQuery(useSeasonListQuery(submittedC));
+
+	const [errors, setErrors] = useState<UserInputError>({});
+
+	const handleCompare = () => {
+		const newErrors: UserInputError = {};
+		if (!inputA.trim()) newErrors.userA = "Username required";
+		if (!inputB.trim()) newErrors.userB = "Username required";
+		if (Object.keys(newErrors).length > 0) {
+			setErrors(newErrors);
+			return;
+		}
+		setErrors({});
+
+		navigate({
+			to: "/compare",
+			search: {
+				userA: inputA.trim(),
+				userB: inputB.trim(),
+				userC: showThirdUser && inputC.trim() ? inputC.trim() : undefined,
+				season: selectedSeason,
+				year: selectedYear,
+			},
+		});
+	};
+
+	// Check if we have submitted data to show results
+	const hasSubmitted = submittedA && submittedB && submittedSeason && submittedYear;
+
+	// Loading state
+	const isLoading =
+		hasSubmitted &&
+		(listAQuery.isLoading ||
+			listBQuery.isLoading ||
+			(submittedC && listCQuery.isLoading));
+
+	// Error collection
+	const userErrors: string[] = [];
+	if (userAQuery.error) userErrors.push(`User A (${submittedA}): ${userAQuery.error.message}`);
+	if (userBQuery.error) userErrors.push(`User B (${submittedB}): ${userBQuery.error.message}`);
+	if (submittedC && userCQuery.error) userErrors.push(`User C (${submittedC}): ${userCQuery.error.message}`);
+	if (listAQuery.error) userErrors.push(`User A list (${submittedA}): ${listAQuery.error.message}`);
+	if (listBQuery.error) userErrors.push(`User B list (${submittedB}): ${listBQuery.error.message}`);
+	if (submittedC && listCQuery.error) userErrors.push(`User C list (${submittedC}): ${listCQuery.error.message}`);
+
+	// Process data
+	let mergedEntries: Map<number, import("~/lib/compare-utils").MergedAnimeEntry> | null = null;
+	let stats: import("~/lib/compare-utils").CompareStats | null = null;
+	const activeUsers: { name: string; user: AnilistUser | null }[] = [];
+	const activeUserNames: string[] = [];
+
+	if (hasSubmitted && !isLoading && listAQuery.data && listBQuery.data) {
+		const usersData: { userName: string; entries: SeasonMediaEntry[] }[] = [];
+
+		if (submittedA && listAQuery.data) {
+			const filtered = filterBySeason(listAQuery.data, submittedSeason as AnimeSeason, submittedYear);
+			usersData.push({ userName: submittedA, entries: filtered });
+			activeUsers.push({ name: submittedA, user: userAQuery.data || null });
+			activeUserNames.push(submittedA);
+		}
+
+		if (submittedB && listBQuery.data) {
+			const filtered = filterBySeason(listBQuery.data, submittedSeason as AnimeSeason, submittedYear);
+			usersData.push({ userName: submittedB, entries: filtered });
+			activeUsers.push({ name: submittedB, user: userBQuery.data || null });
+			activeUserNames.push(submittedB);
+		}
+
+		if (submittedC && listCQuery.data) {
+			const filtered = filterBySeason(listCQuery.data, submittedSeason as AnimeSeason, submittedYear);
+			usersData.push({ userName: submittedC, entries: filtered });
+			activeUsers.push({ name: submittedC, user: userCQuery.data || null });
+			activeUserNames.push(submittedC);
+		}
+
+		mergedEntries = mergeUserData(usersData);
+		stats = computeStats(mergedEntries, activeUserNames);
+	}
+
+	return (
+		<main className="min-h-screen bg-gradient-to-br from-pink-50 via-purple-50 to-blue-50 p-8">
+			<div className="max-w-6xl mx-auto">
+				<CompareHeader />
+
+				{/* Input Form */}
+				<Card className="bg-white/90 backdrop-blur-sm border-2 border-pink-200 rounded-3xl shadow-2xl overflow-hidden mb-8">
+					<CardContent className="p-8">
+						<div className="space-y-6">
+							{/* Username inputs */}
+							<div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+								<div>
+									<label className="block text-sm font-bold bg-gradient-to-r from-pink-400 to-rose-400 bg-clip-text text-transparent mb-2">
+										User A
+									</label>
+									<Input
+										type="text"
+										placeholder="AniList Username"
+										value={inputA}
+										onChange={(e) => setInputA(e.target.value)}
+										className={`rounded-2xl border-2 ${errors.userA ? "border-red-300" : "border-pink-100"} focus:border-pink-300 h-12 text-center text-lg`}
+										onKeyDown={(e) => { if (e.key === "Enter") handleCompare(); }}
+									/>
+									{errors.userA && (
+										<p className="text-red-400 text-xs mt-1">{errors.userA}</p>
+									)}
+								</div>
+								<div>
+									<label className="block text-sm font-bold bg-gradient-to-r from-purple-400 to-indigo-400 bg-clip-text text-transparent mb-2">
+										User B
+									</label>
+									<Input
+										type="text"
+										placeholder="AniList Username"
+										value={inputB}
+										onChange={(e) => setInputB(e.target.value)}
+										className={`rounded-2xl border-2 ${errors.userB ? "border-red-300" : "border-purple-100"} focus:border-purple-300 h-12 text-center text-lg`}
+										onKeyDown={(e) => { if (e.key === "Enter") handleCompare(); }}
+									/>
+									{errors.userB && (
+										<p className="text-red-400 text-xs mt-1">{errors.userB}</p>
+									)}
+								</div>
+							</div>
+
+							{/* Third user (optional) */}
+							{showThirdUser ? (
+								<div>
+									<div className="flex items-center justify-between mb-2">
+										<label className="block text-sm font-bold bg-gradient-to-r from-blue-400 to-cyan-400 bg-clip-text text-transparent">
+											User C (Optional)
+										</label>
+										<button
+											type="button"
+											onClick={() => {
+												setShowThirdUser(false);
+												setInputC("");
+											}}
+											className="text-xs text-gray-400 hover:text-red-400 cursor-pointer"
+										>
+											Remove
+										</button>
+									</div>
+									<Input
+										type="text"
+										placeholder="AniList Username"
+										value={inputC}
+										onChange={(e) => setInputC(e.target.value)}
+										className="rounded-2xl border-2 border-blue-100 focus:border-blue-300 h-12 text-center text-lg"
+										onKeyDown={(e) => { if (e.key === "Enter") handleCompare(); }}
+									/>
+								</div>
+							) : (
+								<button
+									type="button"
+									onClick={() => setShowThirdUser(true)}
+									className="text-sm text-purple-400 hover:text-purple-600 font-medium cursor-pointer"
+								>
+									+ Add a third user
+								</button>
+							)}
+
+							{/* Season & Year selectors */}
+							<div className="flex flex-col sm:flex-row gap-4">
+								<div className="flex-1">
+									<label className="block text-sm font-medium text-gray-700 mb-2">
+										Season
+									</label>
+									<Select
+										value={selectedSeason}
+										onValueChange={(v) => setSelectedSeason(v as AnimeSeason)}
+									>
+										<SelectTrigger className="rounded-2xl border-2 border-purple-100 h-12">
+											<SelectValue />
+										</SelectTrigger>
+										<SelectContent>
+											{SEASONS.map((s) => (
+												<SelectItem key={s} value={s}>
+													{s === "WINTER" && "❄️ "}
+													{s === "SPRING" && "🌸 "}
+													{s === "SUMMER" && "☀️ "}
+													{s === "FALL" && "🍂 "}
+													{s}
+												</SelectItem>
+											))}
+										</SelectContent>
+									</Select>
+								</div>
+								<div className="flex-1">
+									<label className="block text-sm font-medium text-gray-700 mb-2">
+										Year
+									</label>
+									<Select
+										value={selectedYear.toString()}
+										onValueChange={(v) => setSelectedYear(Number(v))}
+									>
+										<SelectTrigger className="rounded-2xl border-2 border-purple-100 h-12">
+											<SelectValue />
+										</SelectTrigger>
+										<SelectContent>
+											{years.map((y) => (
+												<SelectItem key={y} value={y.toString()}>
+													{y}
+												</SelectItem>
+											))}
+										</SelectContent>
+									</Select>
+								</div>
+							</div>
+
+							{/* Errors from API */}
+							{userErrors.length > 0 && (
+								<div className="bg-red-50 border-2 border-red-200 rounded-2xl p-4">
+									{userErrors.map((err) => (
+										<p key={err} className="text-sm text-red-600">
+											{err}
+										</p>
+									))}
+								</div>
+							)}
+
+							{/* Compare button */}
+							<Button
+								onClick={handleCompare}
+								disabled={!inputA.trim() || !inputB.trim()}
+								className="w-full bg-gradient-to-r from-pink-400 via-purple-400 to-blue-400 hover:from-pink-500 hover:via-purple-500 hover:to-blue-500 text-white font-bold py-4 px-8 rounded-full shadow-lg hover:shadow-xl transform transition-all duration-300 text-lg disabled:opacity-50"
+							>
+								⚔️ Compare! ⚔️
+							</Button>
+						</div>
+					</CardContent>
+				</Card>
+
+				{/* Results */}
+				{hasSubmitted && (
+					<div className="space-y-8">
+						{isLoading ? (
+							<AnimeLoading />
+						) : mergedEntries && stats ? (
+							<>
+								<div className="text-center mb-4">
+									<h2 className="text-2xl font-bold bg-gradient-to-r from-purple-400 to-blue-400 bg-clip-text text-transparent mb-2">
+										📺 {submittedSeason} {submittedYear} Comparison 📺
+									</h2>
+									<p className="text-gray-600">
+										{mergedEntries.size} anime found across {activeUserNames.length} users
+									</p>
+								</div>
+
+								<CompareTable
+									mergedEntries={mergedEntries}
+									users={activeUsers}
+								/>
+
+								<CompareStats
+									stats={stats}
+									userNames={activeUserNames}
+								/>
+							</>
+						) : null}
+					</div>
+				)}
+			</div>
+		</main>
+	);
+}


### PR DESCRIPTION
## Summary
- New `/compare` page to compare anime watching habits between 2-3 AniList users for a given season
- Sortable comparison table showing each user's score, status, and progress side-by-side
- Statistics section with 4 tabs: Overview cards, Score Distribution (bar chart), Genre Preferences (radar chart), Tags & Biggest Disagreements/Agreements
- Navigation bar added to root layout for switching between Watching and Compare pages
- URL search params for shareable comparison links (`/compare?userA=...&userB=...&season=SPRING&year=2026`)

## Test plan
- [ ] Navigate to `/compare` and verify the form renders with username inputs, season/year selectors
- [ ] Enter two valid AniList usernames, pick a season with data, click Compare
- [ ] Verify the comparison table shows anime with correct scores and statuses for both users
- [ ] Test sorting by anime title, user scores, and AL average
- [ ] Click "+ Add a third user", enter a third username, and verify 3-user comparison works
- [ ] Check all 4 statistics tabs render correctly (Overview, Scores, Genres, Tags & Opinions)
- [ ] Test with an invalid username and verify error message appears
- [ ] Verify nav bar links work on both pages
- [ ] Copy the URL with search params and open in a new tab to verify shareability

🤖 Generated with [Claude Code](https://claude.com/claude-code)