### PR TITLE
Simplify compare and game pages

### DIFF
--- a/src/components/CompareStats.tsx
+++ b/src/components/CompareStats.tsx
@@ -21,12 +21,7 @@ import {
 	type ChartConfig,
 } from "~/components/ui/chart";
 
-const USER_COLORS = ["#f472b6", "#a78bfa", "#60a5fa"];
-const USER_GRADIENT_CLASSES = [
-	"from-pink-400 to-rose-400",
-	"from-purple-400 to-indigo-400",
-	"from-blue-400 to-cyan-400",
-];
+import { USER_HEX_COLORS, USER_GRADIENT_CLASSES } from "~/lib/constants";
 
 interface CompareStatsProps {
 	stats: CompareStatsType;
@@ -87,7 +82,7 @@ function OverviewCards({ stats, userNames }: CompareStatsProps) {
 										className="h-full rounded-full transition-all duration-500"
 										style={{
 											width: `${(avg / 10) * 100}%`,
-											backgroundColor: USER_COLORS[i],
+											backgroundColor: USER_HEX_COLORS[i],
 										}}
 									/>
 								</div>
@@ -141,7 +136,7 @@ function ScoreDistributionChart({ stats, userNames }: CompareStatsProps) {
 	for (let i = 0; i < userNames.length; i++) {
 		chartConfig[userNames[i]] = {
 			label: userNames[i],
-			color: USER_COLORS[i],
+			color: USER_HEX_COLORS[i],
 		};
 	}
 
@@ -159,7 +154,7 @@ function ScoreDistributionChart({ stats, userNames }: CompareStatsProps) {
 						<Bar
 							key={name}
 							dataKey={name}
-							fill={USER_COLORS[i]}
+							fill={USER_HEX_COLORS[i]}
 							radius={[4, 4, 0, 0]}
 						/>
 					))}
@@ -206,7 +201,7 @@ function GenreRadarChart({ stats, userNames }: CompareStatsProps) {
 	for (let i = 0; i < userNames.length; i++) {
 		chartConfig[userNames[i]] = {
 			label: userNames[i],
-			color: USER_COLORS[i],
+			color: USER_HEX_COLORS[i],
 		};
 	}
 
@@ -224,8 +219,8 @@ function GenreRadarChart({ stats, userNames }: CompareStatsProps) {
 							key={name}
 							name={name}
 							dataKey={name}
-							stroke={USER_COLORS[i]}
-							fill={USER_COLORS[i]}
+							stroke={USER_HEX_COLORS[i]}
+							fill={USER_HEX_COLORS[i]}
 							fillOpacity={0.15}
 						/>
 					))}
@@ -262,7 +257,7 @@ function TagsAndDisagreements({ stats, userNames }: CompareStatsProps) {
 												key={tag}
 												variant="outline"
 												className="text-xs"
-												style={{ borderColor: USER_COLORS[i], color: USER_COLORS[i] }}
+												style={{ borderColor: USER_HEX_COLORS[i], color: USER_HEX_COLORS[i] }}
 											>
 												{tag} ({count})
 											</Badge>
@@ -300,7 +295,7 @@ function TagsAndDisagreements({ stats, userNames }: CompareStatsProps) {
 									</p>
 									<div className="flex gap-2 mt-1">
 										{userNames.map((name, i) => (
-											<span key={name} className="text-xs" style={{ color: USER_COLORS[i] }}>
+											<span key={name} className="text-xs" style={{ color: USER_HEX_COLORS[i] }}>
 												{item.scores[name] != null ? `${name}: ${item.scores[name]}` : ""}
 											</span>
 										))}
@@ -338,7 +333,7 @@ function TagsAndDisagreements({ stats, userNames }: CompareStatsProps) {
 									</p>
 									<div className="flex gap-2 mt-1">
 										{userNames.map((name, i) => (
-											<span key={name} className="text-xs" style={{ color: USER_COLORS[i] }}>
+											<span key={name} className="text-xs" style={{ color: USER_HEX_COLORS[i] }}>
 												{item.scores[name] != null ? `${name}: ${item.scores[name]}` : ""}
 											</span>
 										))}

--- a/src/components/CompareTable.tsx
+++ b/src/components/CompareTable.tsx
@@ -43,7 +43,7 @@ function getStatusBadge(status: string) {
 	);
 }
 
-const USER_COLORS = ["from-pink-400 to-rose-400", "from-purple-400 to-indigo-400", "from-blue-400 to-cyan-400"];
+import { USER_GRADIENT_CLASSES } from "~/lib/constants";
 
 function getUserAvgScore(entry: MergedAnimeEntry, users: CompareTableProps["users"]): number {
 	const scores = users
@@ -81,7 +81,7 @@ export function CompareTable({ mergedEntries, users }: CompareTableProps) {
 	const [sortDir, setSortDir] = useState<SortDir>("asc");
 	const [selectedGenres, setSelectedGenres] = useState<Set<string>>(new Set());
 
-	const entries = Array.from(mergedEntries.values());
+	const entries = useMemo(() => Array.from(mergedEntries.values()), [mergedEntries]);
 
 	// Collect all genres with counts
 	const genreCounts = useMemo(() => {
@@ -216,7 +216,7 @@ export function CompareTable({ mergedEntries, users }: CompareTableProps) {
 												className="w-6 h-6 rounded-full"
 											/>
 										)}
-										<span className={`bg-gradient-to-r ${USER_COLORS[i]} bg-clip-text text-transparent font-bold`}>
+										<span className={`bg-gradient-to-r ${USER_GRADIENT_CLASSES[i]} bg-clip-text text-transparent font-bold`}>
 											{u.name}
 										</span>
 										<span className="text-[10px] text-gray-400">{sortIcon(u.name)}</span>
@@ -238,7 +238,9 @@ export function CompareTable({ mergedEntries, users }: CompareTableProps) {
 						</TableRow>
 					</TableHeader>
 					<TableBody>
-						{sorted.map((entry) => (
+						{sorted.map((entry) => {
+							const avg = getUserAvgScore(entry, users);
+							return (
 							<TableRow key={entry.media.id} className="hover:bg-purple-50/30 transition-colors">
 								<TableCell>
 									<div className="flex items-center gap-3">
@@ -296,14 +298,9 @@ export function CompareTable({ mergedEntries, users }: CompareTableProps) {
 									);
 								})}
 								<TableCell className="text-center">
-									{(() => {
-										const avg = getUserAvgScore(entry, users);
-										return (
-											<span className={`inline-flex items-center justify-center w-8 h-8 rounded-full text-sm font-bold ${getScoreColor(avg)}`}>
-												{avg > 0 ? avg.toFixed(1) : "-"}
-											</span>
-										);
-									})()}
+									<span className={`inline-flex items-center justify-center w-8 h-8 rounded-full text-sm font-bold ${getScoreColor(avg)}`}>
+										{avg > 0 ? avg.toFixed(1) : "-"}
+									</span>
 								</TableCell>
 								<TableCell className="text-center">
 									<span className="text-sm text-gray-600 font-medium">
@@ -311,7 +308,8 @@ export function CompareTable({ mergedEntries, users }: CompareTableProps) {
 									</span>
 								</TableCell>
 							</TableRow>
-						))}
+							);
+						})}
 					</TableBody>
 				</Table>
 			</div>

--- a/src/components/GameBoard.tsx
+++ b/src/components/GameBoard.tsx
@@ -9,14 +9,14 @@ import {
 	TableHeader,
 	TableRow,
 } from "~/components/ui/table";
+import { useMemo } from "react";
+import { USER_GRADIENT_CLASSES } from "~/lib/constants";
 
 interface GameBoardProps {
 	mergedEntries: Map<number, MergedAnimeEntry>;
 	users: { name: string; user: AnilistUser | null }[];
 	userNames: string[];
 }
-
-const USER_COLORS = ["from-pink-400 to-rose-400", "from-purple-400 to-indigo-400", "from-blue-400 to-cyan-400"];
 
 interface GameRow {
 	entry: MergedAnimeEntry;
@@ -63,7 +63,10 @@ function computeGameRows(
 }
 
 export function GameBoard({ mergedEntries, users, userNames }: GameBoardProps) {
-	const { rows, totalScore, basePoints, bonusPoints } = computeGameRows(mergedEntries, userNames);
+	const { rows, totalScore, basePoints, bonusPoints } = useMemo(
+		() => computeGameRows(mergedEntries, userNames),
+		[mergedEntries, userNames],
+	);
 
 	if (rows.length === 0) {
 		return (
@@ -127,7 +130,7 @@ export function GameBoard({ mergedEntries, users, userNames }: GameBoardProps) {
 												className="w-6 h-6 rounded-full"
 											/>
 										)}
-										<span className={`bg-gradient-to-r ${USER_COLORS[i]} bg-clip-text text-transparent font-bold`}>
+										<span className={`bg-gradient-to-r ${USER_GRADIENT_CLASSES[i]} bg-clip-text text-transparent font-bold`}>
 											{u.name}
 										</span>
 									</div>

--- a/src/hooks/useSeasonComparison.ts
+++ b/src/hooks/useSeasonComparison.ts
@@ -1,0 +1,163 @@
+import { useQuery } from "@tanstack/react-query";
+import { useMemo, useState } from "react";
+import { useNavigate } from "@tanstack/react-router";
+import { z } from "zod";
+import type { AnimeSeason, AnilistUser, SeasonMediaEntry } from "server";
+import { userQueryOptions, seasonListQueryOptions } from "~/lib/queries";
+import {
+	getCurrentSeason,
+	getYearRange,
+	SEASONS,
+	filterBySeason,
+	mergeUserData,
+	type MergedAnimeEntry,
+} from "~/lib/compare-utils";
+
+export const seasonSearchSchema = z.object({
+	userA: z.string().optional(),
+	userB: z.string().optional(),
+	userC: z.string().optional(),
+	season: z.enum(["WINTER", "SPRING", "SUMMER", "FALL"]).optional(),
+	year: z.coerce.number().optional(),
+});
+
+export type SeasonSearch = z.infer<typeof seasonSearchSchema>;
+
+const YEARS = getYearRange();
+
+export function useSeasonComparison(
+	search: SeasonSearch,
+	navigateTo: "/compare" | "/game",
+) {
+	const navigate = useNavigate();
+	const currentSeason = getCurrentSeason();
+
+	const [inputA, setInputA] = useState(search.userA || "sanfordmarshall");
+	const [inputB, setInputB] = useState(search.userB || "Jediahsk");
+	const [inputC, setInputC] = useState(search.userC || "");
+	const [showThirdUser, setShowThirdUser] = useState(!!search.userC);
+	const [selectedSeason, setSelectedSeason] = useState<AnimeSeason>(
+		search.season || currentSeason.season,
+	);
+	const [selectedYear, setSelectedYear] = useState(
+		search.year || currentSeason.year,
+	);
+	const [errors, setErrors] = useState<Record<string, string>>({});
+
+	const submittedA = search.userA;
+	const submittedB = search.userB;
+	const submittedC = search.userC;
+	const submittedSeason = search.season;
+	const submittedYear = search.year;
+
+	const userAQuery = useQuery(userQueryOptions(submittedA));
+	const userBQuery = useQuery(userQueryOptions(submittedB));
+	const userCQuery = useQuery(userQueryOptions(submittedC));
+
+	const listAQuery = useQuery(seasonListQueryOptions(submittedA));
+	const listBQuery = useQuery(seasonListQueryOptions(submittedB));
+	const listCQuery = useQuery(seasonListQueryOptions(submittedC));
+
+	const handleSubmit = () => {
+		const newErrors: Record<string, string> = {};
+		if (!inputA.trim()) newErrors.userA = "Username required";
+		if (!inputB.trim()) newErrors.userB = "Username required";
+		if (Object.keys(newErrors).length > 0) {
+			setErrors(newErrors);
+			return;
+		}
+		setErrors({});
+
+		navigate({
+			to: navigateTo,
+			search: {
+				userA: inputA.trim(),
+				userB: inputB.trim(),
+				userC: showThirdUser && inputC.trim() ? inputC.trim() : undefined,
+				season: selectedSeason,
+				year: selectedYear,
+			},
+		});
+	};
+
+	const hasSubmitted = !!(submittedA && submittedB && submittedSeason && submittedYear);
+
+	const isLoading =
+		hasSubmitted &&
+		(listAQuery.isLoading ||
+			listBQuery.isLoading ||
+			!!(submittedC && listCQuery.isLoading));
+
+	const userErrors: string[] = [];
+	if (userAQuery.error) userErrors.push(`User A (${submittedA}): ${userAQuery.error.message}`);
+	if (userBQuery.error) userErrors.push(`User B (${submittedB}): ${userBQuery.error.message}`);
+	if (submittedC && userCQuery.error) userErrors.push(`User C (${submittedC}): ${userCQuery.error.message}`);
+	if (listAQuery.error) userErrors.push(`User A list (${submittedA}): ${listAQuery.error.message}`);
+	if (listBQuery.error) userErrors.push(`User B list (${submittedB}): ${listBQuery.error.message}`);
+	if (submittedC && listCQuery.error) userErrors.push(`User C list (${submittedC}): ${listCQuery.error.message}`);
+
+	const { mergedEntries, activeUsers, activeUserNames } = useMemo(() => {
+		if (!hasSubmitted || isLoading || !listAQuery.data || !listBQuery.data) {
+			return { mergedEntries: null, activeUsers: [] as { name: string; user: AnilistUser | null }[], activeUserNames: [] as string[] };
+		}
+
+		const usersData: { userName: string; entries: SeasonMediaEntry[] }[] = [];
+		const users: { name: string; user: AnilistUser | null }[] = [];
+		const names: string[] = [];
+
+		if (submittedA && listAQuery.data) {
+			usersData.push({ userName: submittedA, entries: filterBySeason(listAQuery.data, submittedSeason as AnimeSeason, submittedYear!) });
+			users.push({ name: submittedA, user: userAQuery.data || null });
+			names.push(submittedA);
+		}
+
+		if (submittedB && listBQuery.data) {
+			usersData.push({ userName: submittedB, entries: filterBySeason(listBQuery.data, submittedSeason as AnimeSeason, submittedYear!) });
+			users.push({ name: submittedB, user: userBQuery.data || null });
+			names.push(submittedB);
+		}
+
+		if (submittedC && listCQuery.data) {
+			usersData.push({ userName: submittedC, entries: filterBySeason(listCQuery.data, submittedSeason as AnimeSeason, submittedYear!) });
+			users.push({ name: submittedC, user: userCQuery.data || null });
+			names.push(submittedC);
+		}
+
+		return {
+			mergedEntries: mergeUserData(usersData),
+			activeUsers: users,
+			activeUserNames: names,
+		};
+	}, [
+		hasSubmitted, isLoading,
+		submittedA, submittedB, submittedC,
+		submittedSeason, submittedYear,
+		listAQuery.data, listBQuery.data, listCQuery.data,
+		userAQuery.data, userBQuery.data, userCQuery.data,
+	]);
+
+	return {
+		// Form state
+		inputA, setInputA,
+		inputB, setInputB,
+		inputC, setInputC,
+		showThirdUser, setShowThirdUser,
+		selectedSeason, setSelectedSeason,
+		selectedYear, setSelectedYear,
+		errors,
+		years: YEARS,
+
+		// Submission
+		handleSubmit,
+		hasSubmitted,
+		isLoading,
+		userErrors,
+
+		// Processed data
+		mergedEntries,
+		activeUsers,
+		activeUserNames,
+		submittedSeason,
+		submittedYear,
+	};
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,16 @@
+import type { AnimeSeason } from "server";
+
+export const USER_GRADIENT_CLASSES = [
+	"from-pink-400 to-rose-400",
+	"from-purple-400 to-indigo-400",
+	"from-blue-400 to-cyan-400",
+];
+
+export const USER_HEX_COLORS = ["#f472b6", "#a78bfa", "#60a5fa"];
+
+export const SEASON_EMOJI: Record<AnimeSeason, string> = {
+	WINTER: "❄️",
+	SPRING: "🌸",
+	SUMMER: "☀️",
+	FALL: "🍂",
+};

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -1,0 +1,35 @@
+import { queryOptions } from "@tanstack/react-query";
+import { getCurrentUser, getSeasonAnimeList } from "server";
+
+export const userQueryOptions = (userName: string | undefined) =>
+	queryOptions({
+		queryKey: ["user", userName],
+		queryFn: async () => {
+			if (!userName) throw new Error("No username");
+			const response = await getCurrentUser({ data: { userName } });
+			if (response.errors?.length) {
+				throw new Error(response.errors[0].message);
+			}
+			return response.data.User;
+		},
+		enabled: !!userName,
+		retry: false,
+		staleTime: 5 * 60 * 1000,
+	});
+
+export const seasonListQueryOptions = (userName: string | undefined) =>
+	queryOptions({
+		queryKey: ["seasonAnimeList", userName],
+		queryFn: async () => {
+			if (!userName) throw new Error("No username");
+			const response = await getSeasonAnimeList({ data: { userName } });
+			if (response.errors?.length) {
+				throw new Error(response.errors[0].message);
+			}
+			const lists = response.data.MediaListCollection?.lists || [];
+			return lists.flatMap((list) => list.entries);
+		},
+		enabled: !!userName,
+		retry: false,
+		staleTime: 5 * 60 * 1000,
+	});

--- a/src/routes/compare.tsx
+++ b/src/routes/compare.tsx
@@ -1,14 +1,6 @@
-import { queryOptions, useQuery } from "@tanstack/react-query";
-import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { useState } from "react";
-import { z } from "zod";
-import {
-	getCurrentUser,
-	getSeasonAnimeList,
-	type AnimeSeason,
-	type AnilistUser,
-	type SeasonMediaEntry,
-} from "server";
+import { createFileRoute } from "@tanstack/react-router";
+import { useMemo } from "react";
+import type { AnimeSeason } from "server";
 import { Button } from "~/components/ui/button";
 import { Card, CardContent } from "~/components/ui/card";
 import { Input } from "~/components/ui/input";
@@ -22,214 +14,52 @@ import {
 import { AnimeLoading } from "~/components/KawaiiLoading";
 import { CompareTable } from "~/components/CompareTable";
 import { CompareStats } from "~/components/CompareStats";
-import {
-	getCurrentSeason,
-	getYearRange,
-	SEASONS,
-	filterBySeason,
-	mergeUserData,
-	computeStats,
-} from "~/lib/compare-utils";
-
-// ============================================================================
-// Route Definition
-// ============================================================================
-
-const compareSearchSchema = z.object({
-	userA: z.string().optional(),
-	userB: z.string().optional(),
-	userC: z.string().optional(),
-	season: z.enum(["WINTER", "SPRING", "SUMMER", "FALL"]).optional(),
-	year: z.coerce.number().optional(),
-});
+import { SEASONS, computeStats } from "~/lib/compare-utils";
+import { SEASON_EMOJI } from "~/lib/constants";
+import { seasonSearchSchema } from "~/hooks/useSeasonComparison";
+import { useSeasonComparison } from "~/hooks/useSeasonComparison";
 
 export const Route = createFileRoute("/compare")({
 	component: ComparePage,
-	validateSearch: compareSearchSchema,
+	validateSearch: seasonSearchSchema,
 });
-
-// ============================================================================
-// Query Options
-// ============================================================================
-
-const useUserQuery = (userName: string | undefined) =>
-	queryOptions({
-		queryKey: ["user", userName],
-		queryFn: async () => {
-			if (!userName) throw new Error("No username");
-			const response = await getCurrentUser({ data: { userName } });
-			if (response.errors?.length) {
-				throw new Error(response.errors[0].message);
-			}
-			return response.data.User;
-		},
-		enabled: !!userName,
-		retry: false,
-		staleTime: 5 * 60 * 1000,
-	});
-
-const useSeasonListQuery = (userName: string | undefined) =>
-	queryOptions({
-		queryKey: ["seasonAnimeList", userName],
-		queryFn: async () => {
-			if (!userName) throw new Error("No username");
-			const response = await getSeasonAnimeList({ data: { userName } });
-			if (response.errors?.length) {
-				throw new Error(response.errors[0].message);
-			}
-			const lists = response.data.MediaListCollection?.lists || [];
-			return lists.flatMap((list) => list.entries);
-		},
-		enabled: !!userName,
-		retry: false,
-		staleTime: 5 * 60 * 1000,
-	});
-
-// ============================================================================
-// Components
-// ============================================================================
-
-function CompareHeader() {
-	return (
-		<div className="text-center mb-8">
-			<h1 className="text-4xl font-bold bg-gradient-to-r from-pink-400 via-purple-400 to-blue-400 bg-clip-text text-transparent mb-2">
-				⚔️ Compare Season Anime ⚔️
-			</h1>
-			<p className="text-lg text-gray-600 font-medium">
-				(^_^) Compare your anime taste with friends!
-			</p>
-		</div>
-	);
-}
-
-interface UserInputError {
-	userA?: string;
-	userB?: string;
-	userC?: string;
-}
 
 function ComparePage() {
 	const search = Route.useSearch();
-	const navigate = useNavigate();
-	const currentSeason = getCurrentSeason();
-	const years = getYearRange();
+	const {
+		inputA, setInputA,
+		inputB, setInputB,
+		inputC, setInputC,
+		showThirdUser, setShowThirdUser,
+		selectedSeason, setSelectedSeason,
+		selectedYear, setSelectedYear,
+		errors, years,
+		handleSubmit,
+		hasSubmitted, isLoading, userErrors,
+		mergedEntries, activeUsers, activeUserNames,
+		submittedSeason, submittedYear,
+	} = useSeasonComparison(search, "/compare");
 
-	// Local form state (before submitting)
-	const [inputA, setInputA] = useState(search.userA || "sanfordmarshall");
-	const [inputB, setInputB] = useState(search.userB || "Jediahsk");
-	const [inputC, setInputC] = useState(search.userC || "");
-	const [showThirdUser, setShowThirdUser] = useState(!!search.userC);
-	const [selectedSeason, setSelectedSeason] = useState<AnimeSeason>(
-		search.season || currentSeason.season,
-	);
-	const [selectedYear, setSelectedYear] = useState(
-		search.year || currentSeason.year,
-	);
-
-	// "submitted" usernames (from URL search params)
-	const submittedA = search.userA;
-	const submittedB = search.userB;
-	const submittedC = search.userC;
-	const submittedSeason = search.season;
-	const submittedYear = search.year;
-
-	// User profile queries
-	const userAQuery = useQuery(useUserQuery(submittedA));
-	const userBQuery = useQuery(useUserQuery(submittedB));
-	const userCQuery = useQuery(useUserQuery(submittedC));
-
-	// Anime list queries
-	const listAQuery = useQuery(useSeasonListQuery(submittedA));
-	const listBQuery = useQuery(useSeasonListQuery(submittedB));
-	const listCQuery = useQuery(useSeasonListQuery(submittedC));
-
-	const [errors, setErrors] = useState<UserInputError>({});
-
-	const handleCompare = () => {
-		const newErrors: UserInputError = {};
-		if (!inputA.trim()) newErrors.userA = "Username required";
-		if (!inputB.trim()) newErrors.userB = "Username required";
-		if (Object.keys(newErrors).length > 0) {
-			setErrors(newErrors);
-			return;
-		}
-		setErrors({});
-
-		navigate({
-			to: "/compare",
-			search: {
-				userA: inputA.trim(),
-				userB: inputB.trim(),
-				userC: showThirdUser && inputC.trim() ? inputC.trim() : undefined,
-				season: selectedSeason,
-				year: selectedYear,
-			},
-		});
-	};
-
-	// Check if we have submitted data to show results
-	const hasSubmitted = submittedA && submittedB && submittedSeason && submittedYear;
-
-	// Loading state
-	const isLoading =
-		hasSubmitted &&
-		(listAQuery.isLoading ||
-			listBQuery.isLoading ||
-			(submittedC && listCQuery.isLoading));
-
-	// Error collection
-	const userErrors: string[] = [];
-	if (userAQuery.error) userErrors.push(`User A (${submittedA}): ${userAQuery.error.message}`);
-	if (userBQuery.error) userErrors.push(`User B (${submittedB}): ${userBQuery.error.message}`);
-	if (submittedC && userCQuery.error) userErrors.push(`User C (${submittedC}): ${userCQuery.error.message}`);
-	if (listAQuery.error) userErrors.push(`User A list (${submittedA}): ${listAQuery.error.message}`);
-	if (listBQuery.error) userErrors.push(`User B list (${submittedB}): ${listBQuery.error.message}`);
-	if (submittedC && listCQuery.error) userErrors.push(`User C list (${submittedC}): ${listCQuery.error.message}`);
-
-	// Process data
-	let mergedEntries: Map<number, import("~/lib/compare-utils").MergedAnimeEntry> | null = null;
-	let stats: import("~/lib/compare-utils").CompareStats | null = null;
-	const activeUsers: { name: string; user: AnilistUser | null }[] = [];
-	const activeUserNames: string[] = [];
-
-	if (hasSubmitted && !isLoading && listAQuery.data && listBQuery.data) {
-		const usersData: { userName: string; entries: SeasonMediaEntry[] }[] = [];
-
-		if (submittedA && listAQuery.data) {
-			const filtered = filterBySeason(listAQuery.data, submittedSeason as AnimeSeason, submittedYear);
-			usersData.push({ userName: submittedA, entries: filtered });
-			activeUsers.push({ name: submittedA, user: userAQuery.data || null });
-			activeUserNames.push(submittedA);
-		}
-
-		if (submittedB && listBQuery.data) {
-			const filtered = filterBySeason(listBQuery.data, submittedSeason as AnimeSeason, submittedYear);
-			usersData.push({ userName: submittedB, entries: filtered });
-			activeUsers.push({ name: submittedB, user: userBQuery.data || null });
-			activeUserNames.push(submittedB);
-		}
-
-		if (submittedC && listCQuery.data) {
-			const filtered = filterBySeason(listCQuery.data, submittedSeason as AnimeSeason, submittedYear);
-			usersData.push({ userName: submittedC, entries: filtered });
-			activeUsers.push({ name: submittedC, user: userCQuery.data || null });
-			activeUserNames.push(submittedC);
-		}
-
-		mergedEntries = mergeUserData(usersData);
-		stats = computeStats(mergedEntries, activeUserNames);
-	}
+	const stats = useMemo(() => {
+		if (!mergedEntries) return null;
+		return computeStats(mergedEntries, activeUserNames);
+	}, [mergedEntries, activeUserNames]);
 
 	return (
 		<main className="min-h-screen bg-gradient-to-br from-pink-50 via-purple-50 to-blue-50 p-8">
 			<div className="max-w-6xl mx-auto">
-				<CompareHeader />
+				<div className="text-center mb-8">
+					<h1 className="text-4xl font-bold bg-gradient-to-r from-pink-400 via-purple-400 to-blue-400 bg-clip-text text-transparent mb-2">
+						⚔️ Compare Season Anime ⚔️
+					</h1>
+					<p className="text-lg text-gray-600 font-medium">
+						(^_^) Compare your anime taste with friends!
+					</p>
+				</div>
 
-				{/* Input Form */}
 				<Card className="bg-white/90 backdrop-blur-sm border-2 border-pink-200 rounded-3xl shadow-2xl overflow-hidden mb-8">
 					<CardContent className="p-8">
 						<div className="space-y-6">
-							{/* Username inputs */}
 							<div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
 								<div>
 									<label className="block text-sm font-bold bg-gradient-to-r from-pink-400 to-rose-400 bg-clip-text text-transparent mb-2">
@@ -241,11 +71,9 @@ function ComparePage() {
 										value={inputA}
 										onChange={(e) => setInputA(e.target.value)}
 										className={`rounded-2xl border-2 ${errors.userA ? "border-red-300" : "border-pink-100"} focus:border-pink-300 h-12 text-center text-lg`}
-										onKeyDown={(e) => { if (e.key === "Enter") handleCompare(); }}
+										onKeyDown={(e) => { if (e.key === "Enter") handleSubmit(); }}
 									/>
-									{errors.userA && (
-										<p className="text-red-400 text-xs mt-1">{errors.userA}</p>
-									)}
+									{errors.userA && <p className="text-red-400 text-xs mt-1">{errors.userA}</p>}
 								</div>
 								<div>
 									<label className="block text-sm font-bold bg-gradient-to-r from-purple-400 to-indigo-400 bg-clip-text text-transparent mb-2">
@@ -257,15 +85,12 @@ function ComparePage() {
 										value={inputB}
 										onChange={(e) => setInputB(e.target.value)}
 										className={`rounded-2xl border-2 ${errors.userB ? "border-red-300" : "border-purple-100"} focus:border-purple-300 h-12 text-center text-lg`}
-										onKeyDown={(e) => { if (e.key === "Enter") handleCompare(); }}
+										onKeyDown={(e) => { if (e.key === "Enter") handleSubmit(); }}
 									/>
-									{errors.userB && (
-										<p className="text-red-400 text-xs mt-1">{errors.userB}</p>
-									)}
+									{errors.userB && <p className="text-red-400 text-xs mt-1">{errors.userB}</p>}
 								</div>
 							</div>
 
-							{/* Third user (optional) */}
 							{showThirdUser ? (
 								<div>
 									<div className="flex items-center justify-between mb-2">
@@ -274,10 +99,7 @@ function ComparePage() {
 										</label>
 										<button
 											type="button"
-											onClick={() => {
-												setShowThirdUser(false);
-												setInputC("");
-											}}
+											onClick={() => { setShowThirdUser(false); setInputC(""); }}
 											className="text-xs text-gray-400 hover:text-red-400 cursor-pointer"
 										>
 											Remove
@@ -289,7 +111,7 @@ function ComparePage() {
 										value={inputC}
 										onChange={(e) => setInputC(e.target.value)}
 										className="rounded-2xl border-2 border-blue-100 focus:border-blue-300 h-12 text-center text-lg"
-										onKeyDown={(e) => { if (e.key === "Enter") handleCompare(); }}
+										onKeyDown={(e) => { if (e.key === "Enter") handleSubmit(); }}
 									/>
 								</div>
 							) : (
@@ -302,68 +124,45 @@ function ComparePage() {
 								</button>
 							)}
 
-							{/* Season & Year selectors */}
 							<div className="flex flex-col sm:flex-row gap-4">
 								<div className="flex-1">
-									<label className="block text-sm font-medium text-gray-700 mb-2">
-										Season
-									</label>
-									<Select
-										value={selectedSeason}
-										onValueChange={(v) => setSelectedSeason(v as AnimeSeason)}
-									>
+									<label className="block text-sm font-medium text-gray-700 mb-2">Season</label>
+									<Select value={selectedSeason} onValueChange={(v) => setSelectedSeason(v as AnimeSeason)}>
 										<SelectTrigger className="rounded-2xl border-2 border-purple-100 h-12">
 											<SelectValue />
 										</SelectTrigger>
 										<SelectContent>
 											{SEASONS.map((s) => (
-												<SelectItem key={s} value={s}>
-													{s === "WINTER" && "❄️ "}
-													{s === "SPRING" && "🌸 "}
-													{s === "SUMMER" && "☀️ "}
-													{s === "FALL" && "🍂 "}
-													{s}
-												</SelectItem>
+												<SelectItem key={s} value={s}>{SEASON_EMOJI[s]} {s}</SelectItem>
 											))}
 										</SelectContent>
 									</Select>
 								</div>
 								<div className="flex-1">
-									<label className="block text-sm font-medium text-gray-700 mb-2">
-										Year
-									</label>
-									<Select
-										value={selectedYear.toString()}
-										onValueChange={(v) => setSelectedYear(Number(v))}
-									>
+									<label className="block text-sm font-medium text-gray-700 mb-2">Year</label>
+									<Select value={selectedYear.toString()} onValueChange={(v) => setSelectedYear(Number(v))}>
 										<SelectTrigger className="rounded-2xl border-2 border-purple-100 h-12">
 											<SelectValue />
 										</SelectTrigger>
 										<SelectContent>
 											{years.map((y) => (
-												<SelectItem key={y} value={y.toString()}>
-													{y}
-												</SelectItem>
+												<SelectItem key={y} value={y.toString()}>{y}</SelectItem>
 											))}
 										</SelectContent>
 									</Select>
 								</div>
 							</div>
 
-							{/* Errors from API */}
 							{userErrors.length > 0 && (
 								<div className="bg-red-50 border-2 border-red-200 rounded-2xl p-4">
 									{userErrors.map((err) => (
-										<p key={err} className="text-sm text-red-600">
-											{err}
-										</p>
+										<p key={err} className="text-sm text-red-600">{err}</p>
 									))}
 								</div>
 							)}
 
-							{/* Compare button */}
 							<Button
-								onClick={handleCompare}
+								onClick={handleSubmit}
 								disabled={!inputA.trim() || !inputB.trim()}
 								className="w-full bg-gradient-to-r from-pink-400 via-purple-400 to-blue-400 hover:from-pink-500 hover:via-purple-500 hover:to-blue-500 text-white font-bold py-4 px-8 rounded-full shadow-lg hover:shadow-xl transform transition-all duration-300 text-lg disabled:opacity-50"
 							>
@@ -373,7 +172,6 @@ function ComparePage() {
 					</CardContent>
 				</Card>
 
-				{/* Results */}
 				{hasSubmitted && (
 					<div className="space-y-8">
 						{isLoading ? (
@@ -388,16 +186,8 @@ function ComparePage() {
 										{mergedEntries.size} anime found across {activeUserNames.length} users
 									</p>
 								</div>
-
-								<CompareTable
-									mergedEntries={mergedEntries}
-									users={activeUsers}
-								/>
-
-								<CompareStats
-									stats={stats}
-									userNames={activeUserNames}
-								/>
+								<CompareTable mergedEntries={mergedEntries} users={activeUsers} />
+								<CompareStats stats={stats} userNames={activeUserNames} />
 							</>
 						) : null}
 					</div>

--- a/src/routes/game.tsx
+++ b/src/routes/game.tsx
@@ -1,14 +1,5 @@
-import { queryOptions, useQuery } from "@tanstack/react-query";
-import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { useState } from "react";
-import { z } from "zod";
-import {
-	getCurrentUser,
-	getSeasonAnimeList,
-	type AnimeSeason,
-	type AnilistUser,
-	type SeasonMediaEntry,
-} from "server";
+import { createFileRoute } from "@tanstack/react-router";
+import type { AnimeSeason } from "server";
 import { Button } from "~/components/ui/button";
 import { Card, CardContent } from "~/components/ui/card";
 import { Input } from "~/components/ui/input";
@@ -21,178 +12,34 @@ import {
 } from "~/components/ui/select";
 import { AnimeLoading } from "~/components/KawaiiLoading";
 import { GameBoard } from "~/components/GameBoard";
-import {
-	getCurrentSeason,
-	getYearRange,
-	SEASONS,
-	filterBySeason,
-	mergeUserData,
-} from "~/lib/compare-utils";
-
-// ============================================================================
-// Route Definition
-// ============================================================================
-
-const gameSearchSchema = z.object({
-	userA: z.string().optional(),
-	userB: z.string().optional(),
-	userC: z.string().optional(),
-	season: z.enum(["WINTER", "SPRING", "SUMMER", "FALL"]).optional(),
-	year: z.coerce.number().optional(),
-});
+import { SEASONS } from "~/lib/compare-utils";
+import { SEASON_EMOJI } from "~/lib/constants";
+import { seasonSearchSchema, useSeasonComparison } from "~/hooks/useSeasonComparison";
 
 export const Route = createFileRoute("/game")({
 	component: GamePage,
-	validateSearch: gameSearchSchema,
+	validateSearch: seasonSearchSchema,
 });
-
-// ============================================================================
-// Query Options
-// ============================================================================
-
-const useUserQuery = (userName: string | undefined) =>
-	queryOptions({
-		queryKey: ["user", userName],
-		queryFn: async () => {
-			if (!userName) throw new Error("No username");
-			const response = await getCurrentUser({ data: { userName } });
-			if (response.errors?.length) {
-				throw new Error(response.errors[0].message);
-			}
-			return response.data.User;
-		},
-		enabled: !!userName,
-		retry: false,
-		staleTime: 5 * 60 * 1000,
-	});
-
-const useSeasonListQuery = (userName: string | undefined) =>
-	queryOptions({
-		queryKey: ["seasonAnimeList", userName],
-		queryFn: async () => {
-			if (!userName) throw new Error("No username");
-			const response = await getSeasonAnimeList({ data: { userName } });
-			if (response.errors?.length) {
-				throw new Error(response.errors[0].message);
-			}
-			const lists = response.data.MediaListCollection?.lists || [];
-			return lists.flatMap((list) => list.entries);
-		},
-		enabled: !!userName,
-		retry: false,
-		staleTime: 5 * 60 * 1000,
-	});
-
-// ============================================================================
-// Components
-// ============================================================================
 
 function GamePage() {
 	const search = Route.useSearch();
-	const navigate = useNavigate();
-	const currentSeason = getCurrentSeason();
-	const years = getYearRange();
-
-	const [inputA, setInputA] = useState(search.userA || "sanfordmarshall");
-	const [inputB, setInputB] = useState(search.userB || "Jediahsk");
-	const [inputC, setInputC] = useState(search.userC || "");
-	const [showThirdUser, setShowThirdUser] = useState(!!search.userC);
-	const [selectedSeason, setSelectedSeason] = useState<AnimeSeason>(
-		search.season || currentSeason.season,
-	);
-	const [selectedYear, setSelectedYear] = useState(
-		search.year || currentSeason.year,
-	);
-
-	const submittedA = search.userA;
-	const submittedB = search.userB;
-	const submittedC = search.userC;
-	const submittedSeason = search.season;
-	const submittedYear = search.year;
-
-	const userAQuery = useQuery(useUserQuery(submittedA));
-	const userBQuery = useQuery(useUserQuery(submittedB));
-	const userCQuery = useQuery(useUserQuery(submittedC));
-
-	const listAQuery = useQuery(useSeasonListQuery(submittedA));
-	const listBQuery = useQuery(useSeasonListQuery(submittedB));
-	const listCQuery = useQuery(useSeasonListQuery(submittedC));
-
-	const [errors, setErrors] = useState<Record<string, string>>({});
-
-	const handlePlay = () => {
-		const newErrors: Record<string, string> = {};
-		if (!inputA.trim()) newErrors.userA = "Username required";
-		if (!inputB.trim()) newErrors.userB = "Username required";
-		if (Object.keys(newErrors).length > 0) {
-			setErrors(newErrors);
-			return;
-		}
-		setErrors({});
-
-		navigate({
-			to: "/game",
-			search: {
-				userA: inputA.trim(),
-				userB: inputB.trim(),
-				userC: showThirdUser && inputC.trim() ? inputC.trim() : undefined,
-				season: selectedSeason,
-				year: selectedYear,
-			},
-		});
-	};
-
-	const hasSubmitted = submittedA && submittedB && submittedSeason && submittedYear;
-
-	const isLoading =
-		hasSubmitted &&
-		(listAQuery.isLoading ||
-			listBQuery.isLoading ||
-			(submittedC && listCQuery.isLoading));
-
-	const userErrors: string[] = [];
-	if (userAQuery.error) userErrors.push(`User A (${submittedA}): ${userAQuery.error.message}`);
-	if (userBQuery.error) userErrors.push(`User B (${submittedB}): ${userBQuery.error.message}`);
-	if (submittedC && userCQuery.error) userErrors.push(`User C (${submittedC}): ${userCQuery.error.message}`);
-	if (listAQuery.error) userErrors.push(`User A list (${submittedA}): ${listAQuery.error.message}`);
-	if (listBQuery.error) userErrors.push(`User B list (${submittedB}): ${listBQuery.error.message}`);
-	if (submittedC && listCQuery.error) userErrors.push(`User C list (${submittedC}): ${listCQuery.error.message}`);
-
-	let mergedEntries: Map<number, import("~/lib/compare-utils").MergedAnimeEntry> | null = null;
-	const activeUsers: { name: string; user: AnilistUser | null }[] = [];
-	const activeUserNames: string[] = [];
-
-	if (hasSubmitted && !isLoading && listAQuery.data && listBQuery.data) {
-		const usersData: { userName: string; entries: SeasonMediaEntry[] }[] = [];
-
-		if (submittedA && listAQuery.data) {
-			const filtered = filterBySeason(listAQuery.data, submittedSeason as AnimeSeason, submittedYear);
-			usersData.push({ userName: submittedA, entries: filtered });
-			activeUsers.push({ name: submittedA, user: userAQuery.data || null });
-			activeUserNames.push(submittedA);
-		}
-
-		if (submittedB && listBQuery.data) {
-			const filtered = filterBySeason(listBQuery.data, submittedSeason as AnimeSeason, submittedYear);
-			usersData.push({ userName: submittedB, entries: filtered });
-			activeUsers.push({ name: submittedB, user: userBQuery.data || null });
-			activeUserNames.push(submittedB);
-		}
-
-		if (submittedC && listCQuery.data) {
-			const filtered = filterBySeason(listCQuery.data, submittedSeason as AnimeSeason, submittedYear);
-			usersData.push({ userName: submittedC, entries: filtered });
-			activeUsers.push({ name: submittedC, user: userCQuery.data || null });
-			activeUserNames.push(submittedC);
-		}
-
-		mergedEntries = mergeUserData(usersData);
-	}
+	const {
+		inputA, setInputA,
+		inputB, setInputB,
+		inputC, setInputC,
+		showThirdUser, setShowThirdUser,
+		selectedSeason, setSelectedSeason,
+		selectedYear, setSelectedYear,
+		errors, years,
+		handleSubmit,
+		hasSubmitted, isLoading, userErrors,
+		mergedEntries, activeUsers, activeUserNames,
+		submittedSeason, submittedYear,
+	} = useSeasonComparison(search, "/game");
 
 	return (
 		<main className="min-h-screen bg-gradient-to-br from-yellow-50 via-amber-50 to-orange-50 p-8">
 			<div className="max-w-6xl mx-auto">
-				{/* Header */}
 				<div className="text-center mb-8">
 					<h1 className="text-4xl font-bold bg-gradient-to-r from-yellow-500 via-amber-500 to-orange-500 bg-clip-text text-transparent mb-2">
 						🎮 Perfect 10 Game 🏆
@@ -205,7 +52,6 @@ function GamePage() {
 					</p>
 				</div>
 
-				{/* Input Form */}
 				<Card className="bg-white/90 backdrop-blur-sm border-2 border-yellow-200 rounded-3xl shadow-2xl overflow-hidden mb-8">
 					<CardContent className="p-8">
 						<div className="space-y-6">
@@ -220,7 +66,7 @@ function GamePage() {
 										value={inputA}
 										onChange={(e) => setInputA(e.target.value)}
 										className={`rounded-2xl border-2 ${errors.userA ? "border-red-300" : "border-yellow-100"} focus:border-yellow-300 h-12 text-center text-lg`}
-										onKeyDown={(e) => { if (e.key === "Enter") handlePlay(); }}
+										onKeyDown={(e) => { if (e.key === "Enter") handleSubmit(); }}
 									/>
 									{errors.userA && <p className="text-red-400 text-xs mt-1">{errors.userA}</p>}
 								</div>
@@ -234,7 +80,7 @@ function GamePage() {
 										value={inputB}
 										onChange={(e) => setInputB(e.target.value)}
 										className={`rounded-2xl border-2 ${errors.userB ? "border-red-300" : "border-amber-100"} focus:border-amber-300 h-12 text-center text-lg`}
-										onKeyDown={(e) => { if (e.key === "Enter") handlePlay(); }}
+										onKeyDown={(e) => { if (e.key === "Enter") handleSubmit(); }}
 									/>
 									{errors.userB && <p className="text-red-400 text-xs mt-1">{errors.userB}</p>}
 								</div>
@@ -260,7 +106,7 @@ function GamePage() {
 										value={inputC}
 										onChange={(e) => setInputC(e.target.value)}
 										className="rounded-2xl border-2 border-orange-100 focus:border-orange-300 h-12 text-center text-lg"
-										onKeyDown={(e) => { if (e.key === "Enter") handlePlay(); }}
+										onKeyDown={(e) => { if (e.key === "Enter") handleSubmit(); }}
 									/>
 								</div>
 							) : (
@@ -282,9 +128,7 @@ function GamePage() {
 										</SelectTrigger>
 										<SelectContent>
 											{SEASONS.map((s) => (
-												<SelectItem key={s} value={s}>
-													{s === "WINTER" && "❄️ "}{s === "SPRING" && "🌸 "}{s === "SUMMER" && "☀️ "}{s === "FALL" && "🍂 "}{s}
-												</SelectItem>
+												<SelectItem key={s} value={s}>{SEASON_EMOJI[s]} {s}</SelectItem>
 											))}
 										</SelectContent>
 									</Select>
@@ -313,7 +157,7 @@ function GamePage() {
 							)}
 
 							<Button
-								onClick={handlePlay}
+								onClick={handleSubmit}
 								disabled={!inputA.trim() || !inputB.trim()}
 								className="w-full bg-gradient-to-r from-yellow-400 via-amber-400 to-orange-400 hover:from-yellow-500 hover:via-amber-500 hover:to-orange-500 text-white font-bold py-4 px-8 rounded-full shadow-lg hover:shadow-xl transform transition-all duration-300 text-lg disabled:opacity-50"
 							>
@@ -323,7 +167,6 @@ function GamePage() {
 					</CardContent>
 				</Card>
 
-				{/* Results */}
 				{hasSubmitted && (
 					<div className="space-y-8">
 						{isLoading ? (
@@ -335,11 +178,7 @@ function GamePage() {
 										🏆 {submittedSeason} {submittedYear} Results 🏆
 									</h2>
 								</div>
-								<GameBoard
-									mergedEntries={mergedEntries}
-									users={activeUsers}
-									userNames={activeUserNames}
-								/>
+								<GameBoard mergedEntries={mergedEntries} users={activeUsers} userNames={activeUserNames} />
 							</>
 						) : null}
 					</div>


### PR DESCRIPTION
## Summary
- **Extract shared hook** (`useSeasonComparison`): form state, React Query hooks, validation, and data processing that was ~80% duplicated between `compare.tsx` and `game.tsx`
- **Centralize constants**: `USER_GRADIENT_CLASSES`, `USER_HEX_COLORS`, `SEASON_EMOJI` were duplicated across 3+ component files — now in `src/lib/constants.ts`
- **Shared query factories** (`src/lib/queries.ts`): `userQueryOptions` and `seasonListQueryOptions` extracted from route files
- **Fix broken memoization**: `CompareTable` had a `useMemo` keyed on `entries` (new array ref every render) — now properly memoized on `mergedEntries`
- **Add missing memoization**: `computeGameRows` in `GameBoard` now wrapped in `useMemo`
- **Remove IIFE pattern** in `CompareTable` render for cleaner code

Net: **-161 lines** across 8 files, no behavior changes.

## Test plan
- [ ] `/compare` page: enter two users, verify table renders with scores, genres, sorting, and stats
- [ ] `/game` page: enter two users, verify game board with scores, PERFECT row multipliers, and totals
- [ ] Add a third user on both pages and verify it works
- [ ] Verify genre filter still works on compare table
- [ ] Run `npx tsc --noEmit` — passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)